### PR TITLE
docs: clarify value proposition and improve comparison with upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,21 @@ Always up-to-date Nix package for [Claude Code](https://claude.ai/code) - AI cod
 
 ### Primary Goal: Always Up-to-Date Claude Code for Nix Users
 
-Both this flake and upstream nixpkgs solve the npm global installation problems. However, this flake exists to provide:
+While both this flake and upstream nixpkgs provide Claude Code as a Nix package, this flake focuses on:
 
 1. **Immediate Updates**: New Claude Code versions available within 24 hours of release
 2. **Dedicated Maintenance**: Focused repository for quick fixes when Claude Code changes
 3. **Flake-First Design**: Direct flake usage with Cachix binary cache
 4. **Custom Wrapper Control**: Ready to adapt when Claude Code adds new validations or requirements
+5. **Node.js 22 LTS**: Latest long-term support version for better performance and security
+
+### Why Not Just Use npm Global?
+
+While `npm install -g @anthropic-ai/claude-code` works, it has limitations for Nix users:
+- **Not Declarative**: Can't be managed in your Nix configuration
+- **Not Reproducible**: Different Node.js versions can cause inconsistencies
+- **Path Conflicts**: Can break when switching Node versions with nvm/asdf
+- **Outside Nix**: Doesn't integrate with Nix's dependency management
 
 ### The Reality of nixpkgs Updates
 
@@ -48,13 +57,14 @@ While Claude Code exists in nixpkgs, our approach offers specific advantages:
 | Feature | npm global | nixpkgs upstream | This Flake |
 |---------|------------|------------------|------------|
 | **Latest Version** | ✅ Always | ❌ Delayed | ✅ Daily updates |
-| **Node.js Version** | ❌ System varies | 🔒 Node.js 20 | ✅ Node.js 22 LTS |
+| **Node.js Version** | ⚠️ User manages | 🔒 Node.js 20 | ✅ Node.js 22 LTS |
 | **Binary Cache** | ❌ None | ✅ NixOS cache | ✅ Cachix |
 | **Declarative Config** | ❌ None | ✅ Yes | ✅ Yes |
-| **Version Pinning** | ❌ Manual | ✅ Channel-based | ✅ Flake lock |
+| **Version Pinning** | ⚠️ Manual | ✅ Channel-based | ✅ Flake lock |
 | **Update Frequency** | ✅ Immediate | ⚠️ Weeks | ✅ < 24 hours |
+| **Reproducible** | ❌ No | ✅ Yes | ✅ Yes |
 | **Sandbox Builds** | ❌ N/A | ✅ Yes | ✅ Yes |
-| **Custom Runtime** | ❌ No | ❌ No | 🔜 Planned |
+| **Path Conflicts** | ⚠️ With nvm/asdf | ✅ Isolated | ✅ Isolated |
 
 ### Key Features
 

--- a/README.md
+++ b/README.md
@@ -6,23 +6,56 @@ Always up-to-date Nix package for [Claude Code](https://claude.ai/code) - AI cod
 
 ## Why this package?
 
-When using development environment managers like devenv, asdf, or nvm, globally installed npm packages can become unavailable or incompatible. This Nix package bundles Claude Code with its own Node.js runtime, ensuring it's always available regardless of your project's Node.js version.
+### The Problem with npm Global Installation
 
-### Always Up-to-Date
+When using `npm install -g @anthropic-ai/claude-code`, you face several challenges:
 
-While Claude Code may be available in nixpkgs, it's not always using the latest version. This repository:
+1. **Node.js Version Conflicts**: Project-specific Node.js versions (via nvm, asdf, devenv) can make globally installed packages unavailable
+2. **Path Issues**: Global npm packages may not be in your PATH when switching Node environments
+3. **Permission Problems**: npm global installs often require sudo and can have permission issues
+4. **Version Management**: No declarative way to pin or manage Claude Code versions across systems
 
-- **Automatically checks for new Claude Code versions daily** via GitHub Actions
-- **Creates pull requests immediately** when updates are available
-- **Ensures you always have access to the latest features** without waiting for nixpkgs updates
-- **Provides pre-built binaries via Cachix** for instant installation
+### Our Solution: Nix Flake with Custom Package
+
+This repository provides a **Nix flake** with a **custom package** that solves all these issues:
+
+- **Nix Flake**: Modern, composable, and reproducible package management
+- **Bundled Node.js 22 LTS Runtime**: Claude Code always runs with a stable, tested Node.js version
+- **Complete Isolation**: Works independently of your project's Node.js setup
+- **Declarative Management**: Pin specific versions in your Nix configuration
+- **Sandbox Compatible**: Pre-fetches dependencies for offline/restricted builds
+- **Binary Cache via Cachix**: Pre-built binaries for instant installation (no compilation needed)
+
+### Why Not Use Upstream nixpkgs?
+
+While Claude Code exists in nixpkgs, our approach offers specific advantages:
+
+1. **Always Latest Version**: Daily automated updates vs waiting for nixpkgs PR reviews and merges
+2. **Node.js Version Control**: We explicitly use Node.js 22 LTS for stability (nixpkgs uses whatever Node.js version is in the channel)
+3. **Flake with Binary Cache**: Direct flake usage with Cachix means instant installation
+4. **Custom Package Implementation**: Full control over the build process for future enhancements (e.g., Bun runtime)
+5. **Dedicated Repository**: Focused maintenance without the complexity of nixpkgs contribution process
+
+### Comparison Table
+
+| Feature | npm global | nixpkgs | This Flake |
+|---------|------------|---------|------------|
+| **Latest Version** | ✅ Always | ❌ Delayed | ✅ Daily updates |
+| **Node.js Isolation** | ❌ Uses system | ✅ Bundled | ✅ Node.js 22 LTS |
+| **Binary Cache** | ❌ None | ✅ NixOS cache | ✅ Cachix |
+| **Declarative Config** | ❌ None | ✅ Yes | ✅ Yes |
+| **Version Pinning** | ❌ Manual | ✅ Channel-based | ✅ Flake lock |
+| **Update Frequency** | ✅ Immediate | ⚠️ Weeks | ✅ < 24 hours |
+| **Sandbox Builds** | ❌ N/A | ✅ Yes | ✅ Yes |
+| **Custom Runtime** | ❌ No | ❌ No | 🔜 Planned |
 
 ### Key Features
 
-- **Bundled Node.js Runtime**: Always works regardless of project-specific Node.js versions
-- **Permission Persistence**: Maintains Claude settings and directory permissions across nix updates
-- **Stable Binary Path**: Uses `~/.local/bin/claude` symlink to prevent macOS permission resets
-- **Home Manager Integration**: Automatically preserves `.claude.json` and `.claude/` directory during switches
+- **Always Up-to-Date**: Automated daily checks and updates via GitHub Actions
+- **Pre-built Binaries**: Cachix provides instant installation without compilation
+- **Flake-native**: Modern Nix flake for composable, reproducible deployments
+- **Home Manager Example**: Sample configuration for permission persistence on macOS
+- **Custom Build Process**: Optimized for Claude Code's specific requirements
 
 ## Quick Start
 
@@ -137,6 +170,32 @@ To enable automatic permission preservation, create `~/.config/nixpkgs/home-mana
   '';
 }
 ```
+
+## Technical Details
+
+### Package Architecture
+
+Our custom `package.nix` implementation:
+
+1. **Pre-fetches npm tarball**: Uses Nix's Fixed Output Derivation (FOD) for reproducible, offline builds
+2. **Bundles Node.js 22 LTS**: Ensures consistent runtime environment across all systems
+3. **Custom wrapper script**: Handles PATH, environment variables, and Claude-specific requirements
+4. **Sandbox compatible**: All network fetching happens during the FOD phase, not build phase
+
+### Runtime Selection
+
+Currently using **Node.js 22 LTS** for:
+- Long-term stability and support
+- Proven compatibility with Claude Code
+- Consistent behavior across platforms
+
+### Future Enhancements
+
+We're exploring support for alternative JavaScript runtimes:
+
+- **Bun**: Potential performance improvements and faster startup times
+- **Deno**: Enhanced security model and TypeScript support
+- **Runtime selection**: Allow users to choose their preferred runtime via overlay options
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -6,27 +6,34 @@ Always up-to-date Nix package for [Claude Code](https://claude.ai/code) - AI cod
 
 ## Why this package?
 
-### The Problem with npm Global Installation
+### Primary Goal: Always Up-to-Date Claude Code for Nix Users
 
-When using `npm install -g @anthropic-ai/claude-code`, you face several challenges:
+Both this flake and upstream nixpkgs solve the npm global installation problems. However, this flake exists to provide:
 
-1. **Node.js Version Conflicts**: Project-specific Node.js versions (via nvm, asdf, devenv) can make globally installed packages unavailable
-2. **Path Issues**: Global npm packages may not be in your PATH when switching Node environments
-3. **Permission Problems**: npm global installs often require sudo and can have permission issues
-4. **Version Management**: No declarative way to pin or manage Claude Code versions across systems
+1. **Immediate Updates**: New Claude Code versions available within 24 hours of release
+2. **Dedicated Maintenance**: Focused repository for quick fixes when Claude Code changes
+3. **Flake-First Design**: Direct flake usage with Cachix binary cache
+4. **Custom Wrapper Control**: Ready to adapt when Claude Code adds new validations or requirements
 
-### Our Solution: Nix Flake with Custom Package
+### The Reality of nixpkgs Updates
 
-This repository provides a **Nix flake** with a **custom package** that solves all these issues:
+While nixpkgs provides Claude Code, the update cycle can be slow:
+- Pull requests can take days to weeks for review and merge
+- Updates depend on maintainer availability
+- You're tied to your nixpkgs channel's update schedule
+- Emergency fixes for breaking changes can be delayed
 
-- **Nix Flake**: Modern, composable, and reproducible package management
-- **Bundled Node.js 22 LTS Runtime**: Claude Code always runs with a stable, tested Node.js version
-- **Complete Isolation**: Works independently of your project's Node.js setup
-- **Declarative Management**: Pin specific versions in your Nix configuration
-- **Sandbox Compatible**: Pre-fetches dependencies for offline/restricted builds
-- **Binary Cache via Cachix**: Pre-built binaries for instant installation (no compilation needed)
+### Our Approach: Dedicated Flake Repository
 
-### Why Not Use Upstream nixpkgs?
+This repository provides:
+
+- **Daily Automated Updates**: GitHub Actions checks for new versions every 24 hours
+- **Instant Availability**: Updates are automatically built and cached to Cachix
+- **Quick Fixes**: When Claude Code breaks or adds new requirements, we can fix immediately
+- **Node.js 22 LTS**: We control the runtime version (upstream locked to Node.js 20)
+- **Future Flexibility**: Prepared to test alternative runtimes like Bun
+
+### Why Not Just Use Upstream nixpkgs?
 
 While Claude Code exists in nixpkgs, our approach offers specific advantages:
 
@@ -38,8 +45,8 @@ While Claude Code exists in nixpkgs, our approach offers specific advantages:
 
 ### Comparison Table
 
-| Feature | npm global | nixpkgs | This Flake |
-|---------|------------|---------|------------|
+| Feature | npm global | nixpkgs upstream | This Flake |
+|---------|------------|------------------|------------|
 | **Latest Version** | ✅ Always | ❌ Delayed | ✅ Daily updates |
 | **Node.js Version** | ❌ System varies | 🔒 Node.js 20 | ✅ Node.js 22 LTS |
 | **Binary Cache** | ❌ None | ✅ NixOS cache | ✅ Cachix |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This repository provides a **Nix flake** with a **custom package** that solves a
 While Claude Code exists in nixpkgs, our approach offers specific advantages:
 
 1. **Always Latest Version**: Daily automated updates vs waiting for nixpkgs PR reviews and merges
-2. **Node.js Version Control**: We explicitly use Node.js 22 LTS for stability (nixpkgs uses whatever Node.js version is in the channel)
+2. **Node.js Version Control**: We use Node.js 22 LTS (upstream is locked to Node.js 20 with no override option)
 3. **Flake with Binary Cache**: Direct flake usage with Cachix means instant installation
 4. **Custom Package Implementation**: Full control over the build process for future enhancements (e.g., Bun runtime)
 5. **Dedicated Repository**: Focused maintenance without the complexity of nixpkgs contribution process
@@ -41,7 +41,7 @@ While Claude Code exists in nixpkgs, our approach offers specific advantages:
 | Feature | npm global | nixpkgs | This Flake |
 |---------|------------|---------|------------|
 | **Latest Version** | ✅ Always | ❌ Delayed | ✅ Daily updates |
-| **Node.js Isolation** | ❌ Uses system | ✅ Bundled | ✅ Node.js 22 LTS |
+| **Node.js Version** | ❌ System varies | 🔒 Node.js 20 | ✅ Node.js 22 LTS |
 | **Binary Cache** | ❌ None | ✅ NixOS cache | ✅ Cachix |
 | **Declarative Config** | ❌ None | ✅ Yes | ✅ Yes |
 | **Version Pinning** | ❌ Manual | ✅ Channel-based | ✅ Flake lock |
@@ -184,10 +184,11 @@ Our custom `package.nix` implementation:
 
 ### Runtime Selection
 
-Currently using **Node.js 22 LTS** for:
-- Long-term stability and support
-- Proven compatibility with Claude Code
-- Consistent behavior across platforms
+Currently using **Node.js 22 LTS** because:
+- Long-term stability and support until April 2027
+- Better performance than Node.js 20 (upstream nixpkgs version)
+- Latest LTS with all security updates
+- Full control over version (upstream is hardcoded to Node.js 20)
 
 ### Future Enhancements
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,14 @@ While both this flake and upstream nixpkgs provide Claude Code as a Nix package,
 
 ### Why Not Just Use npm Global?
 
-While `npm install -g @anthropic-ai/claude-code` works, it has limitations for Nix users:
+While `npm install -g @anthropic-ai/claude-code` works, it has critical limitations:
+- **Disappears on Node.js Switch**: When projects use different Node.js versions (via asdf/nvm), Claude Code becomes unavailable
+- **Must Reinstall Per Version**: Need to install Claude Code separately for each Node.js version
 - **Not Declarative**: Can't be managed in your Nix configuration
 - **Not Reproducible**: Different Node.js versions can cause inconsistencies
-- **Path Conflicts**: Can break when switching Node versions with nvm/asdf
 - **Outside Nix**: Doesn't integrate with Nix's dependency management
+
+**Example Problem**: You're working on a legacy project that uses Node.js 16 via asdf. When you switch to that project, your globally installed Claude Code (from Node.js 22) disappears from your PATH. Both this flake and upstream nixpkgs solve this by bundling Node.js with Claude Code.
 
 ### The Reality of nixpkgs Updates
 
@@ -57,14 +60,14 @@ While Claude Code exists in nixpkgs, our approach offers specific advantages:
 | Feature | npm global | nixpkgs upstream | This Flake |
 |---------|------------|------------------|------------|
 | **Latest Version** | ✅ Always | ❌ Delayed | ✅ Daily updates |
-| **Node.js Version** | ⚠️ User manages | 🔒 Node.js 20 | ✅ Node.js 22 LTS |
+| **Node.js Version** | ⚠️ Per Node install | 🔒 Node.js 20 | ✅ Node.js 22 LTS |
+| **Survives Node Switch** | ❌ Lost on switch | ✅ Always available | ✅ Always available |
 | **Binary Cache** | ❌ None | ✅ NixOS cache | ✅ Cachix |
 | **Declarative Config** | ❌ None | ✅ Yes | ✅ Yes |
 | **Version Pinning** | ⚠️ Manual | ✅ Channel-based | ✅ Flake lock |
 | **Update Frequency** | ✅ Immediate | ⚠️ Weeks | ✅ < 24 hours |
 | **Reproducible** | ❌ No | ✅ Yes | ✅ Yes |
 | **Sandbox Builds** | ❌ N/A | ✅ Yes | ✅ Yes |
-| **Path Conflicts** | ⚠️ With nvm/asdf | ✅ Isolated | ✅ Isolated |
 
 ### Key Features
 


### PR DESCRIPTION
## Summary
Improves documentation to address concerns raised in #8 about the value proposition of this flake.

## Key Clarifications

### Primary Value Proposition
- **Main goal**: Provide always up-to-date Claude Code with rapid maintenance
- **Not competing with upstream** on solving npm problems (both solve that)
- **Competing on**: Update speed, maintenance responsiveness, and flexibility

### Accurate Comparisons
- Both this flake and upstream nixpkgs solve npm global installation issues
- This flake's advantages are:
  1. **Daily updates** vs weeks of waiting for nixpkgs PRs
  2. **Node.js 22 LTS** vs upstream's locked Node.js 20
  3. **Dedicated maintenance** for quick fixes when Claude Code changes
  4. **Flake with Cachix** for instant binary installation

### npm Global Critical Issue
- Highlighted that Claude Code **disappears when switching Node.js versions** with asdf/nvm
- Both this flake and upstream solve this by bundling Node.js

### Technical Verification
- Confirmed upstream uses `nodejs_20` as function parameter (non-overridable)
- Verified our package uses `nodejs_22` with full control
- Documented the real benefits without overstating claims

## Changes
- Rewrote "Why this package?" section to be accurate
- Added "Why Not Just Use npm Global?" section with concrete example
- Updated comparison table to show "Survives Node Switch" advantage
- Corrected Node.js version information with verification
- Removed misleading claims about features that aren't unique

## Closes
Closes #8

The value is clear: **For users who want the latest Claude Code immediately with a dedicated maintainer ready to fix breaking changes, this flake is the solution.**