### PR TITLE
feat: add automated version tagging workflow

### DIFF
--- a/.github/workflows/create-version-tag.yml
+++ b/.github/workflows/create-version-tag.yml
@@ -1,0 +1,55 @@
+name: Create Version Tag
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'package.nix'
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from package.nix
+        id: version
+        run: |
+          VERSION=$(sed -n 's/.*version = "\([^"]*\)".*/\1/p' package.nix | head -1)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if tag exists
+        id: check-tag
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create and push tag
+        if: steps.check-tag.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${{ steps.version.outputs.version }}" -m "Release v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"
+
+      - name: Summary
+        run: |
+          echo "## Tag Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tag:** ${{ steps.version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.check-tag.outputs.exists }}" == "true" ]; then
+            echo "- Tag already exists, skipped" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- Tag created successfully" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## Summary

Adds automated git tagging for each Claude Code version release.

- Creates `vX.Y.Z` tags (e.g., `v2.0.76`) when `package.nix` is updated on main
- Uses annotated tags with release messages
- Idempotent: skips if tag already exists

Closes #144

## How it works

1. Triggers on push to `main` when `package.nix` changes
2. Extracts version from `package.nix`
3. Checks if tag exists
4. Creates and pushes tag if not

## Testing

The workflow will only run after merge to main. To test:
1. Merge this PR
2. The workflow should trigger and create `v2.0.76` tag (if not already backfilled)
3. Or wait for next version update

## Backfill

After merging, we'll run a one-time script to create tags for all 128 historical versions (v1.0.35 through v2.0.76).