### PR TITLE
feat: add moving tags (latest, v1, v2)

### DIFF
--- a/.github/workflows/create-version-tag.yml
+++ b/.github/workflows/create-version-tag.yml
@@ -34,22 +34,54 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create and push tag
-        if: steps.check-tag.outputs.exists == 'false'
+      - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and push version tag
+        if: steps.check-tag.outputs.exists == 'false'
+        run: |
           git tag -a "v${{ steps.version.outputs.version }}" -m "Release v${{ steps.version.outputs.version }}"
           git push origin "v${{ steps.version.outputs.version }}"
+
+      - name: Extract major version
+        id: major
+        run: |
+          MAJOR=$(echo "${{ steps.version.outputs.version }}" | cut -d. -f1)
+          echo "major=$MAJOR" >> $GITHUB_OUTPUT
+
+      - name: Update moving tags
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          MAJOR="${{ steps.major.outputs.major }}"
+
+          # Delete remote tags if they exist (moving tags need force update)
+          git push origin :refs/tags/latest 2>/dev/null || true
+          git push origin :refs/tags/v$MAJOR 2>/dev/null || true
+
+          # Delete local tags if they exist
+          git tag -d latest 2>/dev/null || true
+          git tag -d v$MAJOR 2>/dev/null || true
+
+          # Create new annotated tags
+          git tag -a "latest" -m "Latest release: v$VERSION"
+          git tag -a "v$MAJOR" -m "Latest v$MAJOR release: v$VERSION"
+
+          # Push the moving tags
+          git push origin latest
+          git push origin "v$MAJOR"
 
       - name: Summary
         run: |
           echo "## Tag Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Tag:** ${{ steps.version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ steps.check-tag.outputs.exists }}" == "true" ]; then
-            echo "- Tag already exists, skipped" >> $GITHUB_STEP_SUMMARY
+          echo "| Tag | Points To |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----|-----------|" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.check-tag.outputs.exists }}" == "false" ]; then
+            echo "| v${{ steps.version.outputs.version }} | $(git rev-parse --short HEAD) |" >> $GITHUB_STEP_SUMMARY
           else
-            echo "- Tag created successfully" >> $GITHUB_STEP_SUMMARY
+            echo "| v${{ steps.version.outputs.version }} | (already exists) |" >> $GITHUB_STEP_SUMMARY
           fi
+          echo "| v${{ steps.major.outputs.major }} | v${{ steps.version.outputs.version }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| latest | v${{ steps.version.outputs.version }} |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Adds moving tags that always point to the latest release in each series:

| Tag | Behavior |
|-----|----------|
| `latest` | Always points to newest version |
| `v{major}` | Dynamically created/updated based on version (e.g., `v2` for 2.x.x releases) |

## Usage

```nix
# Pin to exact version
github:sadjow/claude-code-nix?ref=v2.0.76

# Track latest in major version (auto-updates)
github:sadjow/claude-code-nix?ref=v2

# Always latest (auto-updates)
github:sadjow/claude-code-nix?ref=latest
```

## How It Works

The major version tag is **extracted dynamically** from the release version:
- `2.0.76` → updates `v2` and `latest`
- `2.0.77` → updates `v2` and `latest`
- `3.0.0` → would create/update `v3` and `latest`

This means future major versions (v3, v4, etc.) are automatically supported without workflow changes.

## Implementation

- Extracts major version: `cut -d. -f1` (e.g., `2.0.76` → `2`)
- Deletes existing moving tags before recreating (git tags are immutable)
- Uses `|| true` to handle first run when tags don't exist

## After Merge

Will manually create initial `v1` tag pointing to v1.0.128 (last v1 release), since no new v1.x versions will trigger the workflow.