### PR TITLE
feat: add Flakestry registry integration

### DIFF
--- a/.github/workflows/flakestry-publish.yml
+++ b/.github/workflows/flakestry-publish.yml
@@ -1,0 +1,23 @@
+name: "Publish to Flakestry"
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "The existing tag to publish"
+        type: "string"
+        required: true
+
+jobs:
+  publish-flake:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: "write"
+      contents: "read"
+    steps:
+      - uses: flakestry/flakestry-publish@main
+        with:
+          version: "${{ inputs.tag || github.ref_name }}"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # claude-code-nix
 
+[![Flakestry](https://flakestry.dev/api/badge/github/sadjow/claude-code-nix)](https://flakestry.dev/flake/github/sadjow/claude-code-nix)
+
 Always up-to-date Nix package for [Claude Code](https://claude.ai/code) - AI coding assistant in your terminal.
 
 **🚀 Automatically updated hourly** to ensure you always have the latest Claude Code version.
@@ -68,12 +70,14 @@ While Claude Code exists in nixpkgs, our approach offers specific advantages:
 | **Update Frequency** | ✅ Immediate | ⚠️ Weeks | ✅ < 1 hour |
 | **Reproducible** | ❌ No | ✅ Yes | ✅ Yes |
 | **Sandbox Builds** | ❌ N/A | ✅ Yes | ✅ Yes |
+| **Flakestry Registry** | ❌ N/A | ❌ No | ✅ Yes |
 
 ### Key Features
 
 - **Always Up-to-Date**: Automated hourly checks and updates via GitHub Actions
 - **Pre-built Binaries**: Cachix provides instant installation without compilation
 - **Flake-native**: Modern Nix flake for composable, reproducible deployments
+- **Flakestry Published**: Discoverable on [flakestry.dev](https://flakestry.dev/flake/github/sadjow/claude-code-nix)
 - **Home Manager Example**: Sample configuration for permission persistence on macOS
 - **Custom Build Process**: Optimized for Claude Code's specific requirements
 


### PR DESCRIPTION
## Summary

- Add GitHub workflow to publish flake to Flakestry on version tags
- Add Flakestry badge to README
- Add Flakestry entry to comparison table and key features

## What is Flakestry?

[Flakestry](https://flakestry.dev) is a community-driven, open-source registry for Nix flakes. Publishing there increases discoverability for Nix users.

## How it works

The workflow triggers on semantic version tags (`vX.Y.Z`) and uses OIDC authentication (no secrets needed). It integrates seamlessly with the existing `create-version-tag.yml` workflow.

## Test plan

- [x] CI passes on this PR
- [x] After merge, manually trigger `update-claude-code.yml` or wait for next version bump
- [x] Verify Flakestry workflow runs on new version tag
- [x] Check flake appears on https://flakestry.dev