### PR TITLE
feat: make the binary name of the `claude-code-bun` package configurable

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -16,6 +16,7 @@
 , cacert
 , bash
 , runtime ? "node"  # "node" or "bun"
+, bunBinName ? "claude-bun"
 }:
 
 let
@@ -48,7 +49,7 @@ let
       runCmd = "${bun}/bin/bun run";
       nativeBuildInputs = [ bun cacert ];
       description = "Claude Code (Bun) - AI coding assistant in your terminal";
-      binName = "claude-bun";
+      binName = bunBinName;
     };
   };
 


### PR DESCRIPTION
I'd like CC to be installed as `claude`, even if it's using the Bun runtime.