### PR TITLE
fix(native): use autoPatchelfHook and makeBinaryWrapper

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -203,13 +203,12 @@ stdenv.mkDerivation rec {
     description = selected.description;
     homepage = "https://www.anthropic.com/claude-code";
     license = licenses.unfree;
-    platforms =
-      if runtime == "native" then
-        [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" "aarch64-linux" ]
-      else if runtime == "bun" then
-        [ "aarch64-darwin" "aarch64-linux" "x86_64-darwin" "x86_64-linux" ]
-      else
-        platforms.all;
+    platforms = if runtime == "native" then
+      [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" "aarch64-linux" ]
+    else if runtime == "bun" then
+      [ "aarch64-darwin" "aarch64-linux" "x86_64-darwin" "x86_64-linux" ]
+    else
+      platforms.all;
     mainProgram = selected.binName;
   };
 }


### PR DESCRIPTION
Switch native runtime to match [nixpkgs claude-code-bin](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/cl/claude-code-bin/package.nix) approach:
- Use autoPatchelfHook instead of manual patchelf
- Use makeBinaryWrapper instead of shell script wrapper
- Add runtime deps to PATH: procps, ripgrep, bubblewrap, socat
- Set USE_BUILTIN_RIPGREP=0 to use system ripgrep
- Remove dontPatchELF (keep dontStrip for Bun trailer)

Fixes busyloop (currently present in binary and bun version, but not node version) on NixOS. I think this may have always been present but I noticed once the default changed to the binary package. It made claude use 100% CPU on idle and eat memory until it was OOM killed or the computer became unresponsive.

I manually tested on NixOS amd64 that all 3 versions work normally.