### PR TITLE
Fix process name for native runtime wrapper

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -150,6 +150,7 @@ stdenv.mkDerivation rec {
       install -m755 ${nativeBinary} $out/bin/.claude-unwrapped
 
       makeBinaryWrapper $out/bin/.claude-unwrapped $out/bin/${selected.binName} \
+        --inherit-argv0 \
         --set DISABLE_AUTOUPDATER 1 \
         --set DISABLE_INSTALLATION_CHECKS 1 \
         --set USE_BUILTIN_RIPGREP 0 \


### PR DESCRIPTION
## Summary

- Add `--inherit-argv0` to the `makeBinaryWrapper` call for the native runtime
- Without this, `argv[0]` defaults to `.claude-unwrapped` (the inner binary path), causing tools like tmux to display `.claude-unwrapp` as the window title
- With `--inherit-argv0`, the wrapper preserves the caller's `argv[0]` (`claude`), so the process name is correct

## Test plan

- [ ] Build the native runtime package
- [ ] Run `claude` inside tmux
- [ ] Verify `#{pane_current_command}` shows `claude` instead of `.claude-unwrapp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)