### PR TITLE
Update native binary URL for Claude releases

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -48,7 +48,7 @@ let
   };
 
   # Native binary URL
-  nativeBinaryUrl = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${version}/${platform}/claude";
+  nativeBinaryUrl = "https://downloads.claude.ai/claude-code-releases/${version}/${platform}/claude";
 
   # Fetch native binary (only when runtime is native and platform is supported)
   nativeBinary = if runtime == "native" && platform != null then


### PR DESCRIPTION
This uses the Claude binary URL from the official Claude code install script and makes it easier for users of the flake to verify the authenticity of the binaries source as it's a URL clearly owner by Anthropic.