### PR TITLE
Prefer Anthropic-owned domain for native binary downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ The script automatically:
 If you prefer to update manually:
 
 1. Edit `package.nix` and change the `version` field
-2. For each platform, fetch the native binary hash: `nix-prefetch-url https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/VERSION/PLATFORM/claude`
+2. For each platform, fetch the native binary hash: `nix-prefetch-url https://downloads.claude.ai/claude-code-releases/VERSION/PLATFORM/claude`
 3. Update the matching entry in the `nativeHashes` attribute set
 4. Build and test locally: `nix build && ./result/bin/claude --version`
 5. Update `flake.lock`: `nix flake update`

--- a/package.nix
+++ b/package.nix
@@ -30,8 +30,14 @@ let
     "linux-arm64" = "12l25dhnkin5wf6kjwcxi97kd5ahvp81zjchxz57sbli5i7bfmlm";
   };
 
+  # Primary host is the Anthropic-branded CDN so users can verify the source;
+  # the GCS bucket is the direct origin and stays as a fallback if the CDN is
+  # unavailable. The sha256 pin guarantees both resolve to identical bytes.
   nativeBinary = fetchurl {
-    url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${version}/${platform}/claude";
+    urls = [
+      "https://downloads.claude.ai/claude-code-releases/${version}/${platform}/claude"
+      "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${version}/${platform}/claude"
+    ];
     sha256 = nativeHashes.${platform};
   };
 in

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -8,7 +8,12 @@ readonly NC='\033[0m'
 
 readonly NPM_REGISTRY_URL="https://registry.npmjs.org"
 readonly PACKAGE_NAME="@anthropic-ai/claude-code"
-readonly NATIVE_BASE_URL="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
+# Primary CDN is Anthropic-branded so users can verify the source; the GCS
+# bucket is the direct origin and stays as a fallback if the CDN is unavailable.
+readonly NATIVE_BASE_URLS=(
+    "https://downloads.claude.ai/claude-code-releases"
+    "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
+)
 
 readonly NATIVE_PLATFORMS=("darwin-arm64" "darwin-x64" "linux-x64" "linux-arm64")
 
@@ -57,10 +62,18 @@ get_latest_version_from_npm() {
 fetch_native_hash() {
     local version="$1"
     local platform="$2"
-    local binary_url="$NATIVE_BASE_URL/$version/$platform/claude"
 
-    local hash=$(nix-prefetch-url "$binary_url" 2>/dev/null | tail -1)
-    echo "$hash" | tr -d '\n'
+    for base_url in "${NATIVE_BASE_URLS[@]}"; do
+        local binary_url="$base_url/$version/$platform/claude"
+        local hash
+        hash=$(nix-prefetch-url "$binary_url" 2>/dev/null | tail -1)
+        if [ -n "$hash" ]; then
+            echo "$hash" | tr -d '\n'
+            return 0
+        fi
+    done
+
+    return 1
 }
 
 update_package_version() {


### PR DESCRIPTION
## Summary
- Fetch the native binary from `downloads.claude.ai` first, the domain used by Anthropic's official install script, so users can verify the source
- Keep the GCS bucket URL as a fallback so availability is not worse than before
- Apply the same dual-URL logic to `scripts/update-version.sh`
- Picks up the idea from #268 on top of the native-only layout

## Test plan
- [x] `nix-prefetch-url` against both URLs returns the same hash already pinned in `package.nix`
- [x] `nix build .#claude-code` succeeds and `./result/bin/claude --version` reports 2.1.114
- [x] `bash -n scripts/update-version.sh` passes and `--check` mode runs clean