### PR TITLE
fix: inherit argv0 in binary wrapper

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -59,6 +59,7 @@ stdenv.mkDerivation {
     install -m755 ${nativeBinary} $out/bin/.claude-unwrapped
 
     makeBinaryWrapper $out/bin/.claude-unwrapped $out/bin/${binName} \
+      --inherit-argv0 \
       --set DISABLE_AUTOUPDATER 1 \
       --set DISABLE_INSTALLATION_CHECKS 1 \
       --set USE_BUILTIN_RIPGREP 0 \


### PR DESCRIPTION
## Problem

`makeBinaryWrapper` defaults the wrapped binary's `argv[0]` to the full `.claude-unwrapped` store path. That path surfaces verbatim in `/proc/<pid>/cmdline`.

Terminals that read `cmdline` for the foreground process — e.g. GNOME Ptyxis — append it to the tab title. Result: the tab reads

`✳ Claude Code — /nix/store/b4pviq7rl1j13dsbq55nvpgigvwfcg2z-claude-code-2.1.143/bin/.claude-unwrapped`

## Fix

Add `--inherit-argv0` to the `makeBinaryWrapper` call. The compiled wrapper now forwards the `argv[0]` it was invoked with into `.claude-unwrapped`, so `cmdline` reads `claude` as expected.

One line, no behavior change beyond `argv[0]`. claude-code does not dispatch on `argv[0]` (not a busybox-style multicall binary), so this is safe.

Invoking by absolute path still shows that path — correct, honest behavior, not masked.

## Verification

Run two `claude` instances before and after this PR. Run `pgrep -af claude`. See the change in `/proc/<pid>/cmdline`:

| | cmdline |
|---|---|
| before | `80681 /nix/store/.../bin/.claude-unwrapped` |
| after  | `86988 claude` |

## Screenshots

**Before** — full nix store path leaks into Ptyxis tab title:

<img width="1280" height="773" alt="image" src="https://github.com/user-attachments/assets/5d8942da-9075-472a-95a4-44516e02c2e8" />

**After** — title shows `claude`:

<img width="1280" height="773" alt="image" src="https://github.com/user-attachments/assets/935a3a0b-2295-4fa8-b725-e5b1b3712782" />
