### PR TITLE
chore: drop flake-utils

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1785747939,
@@ -36,8 +18,8 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,16 +3,24 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
+    systems.url = "github:nix-systems/default";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs =
+    { self
+    , nixpkgs
+    , systems
+    }:
     let
+      inherit (nixpkgs) lib;
+      eachSystem = f: lib.foldl' lib.recursiveUpdate { } (map f (import systems));
+
       overlay = final: prev: {
         claude-code = final.callPackage ./package.nix { };
       };
     in
-    flake-utils.lib.eachDefaultSystem (system:
+    eachSystem
+      (system:
       let
         pkgs = import nixpkgs {
           inherit system;
@@ -21,12 +29,12 @@
         };
       in
       {
-        packages = {
+        packages.${system} = {
           default = pkgs.claude-code;
           claude-code = pkgs.claude-code;
         };
 
-        apps = {
+        apps.${system} = {
           default = {
             type = "app";
             program = "${pkgs.claude-code}/bin/claude";
@@ -37,7 +45,7 @@
           };
         };
 
-        devShells.default = pkgs.mkShell {
+        devShells.${system}.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             nixpkgs-fmt
             nix-prefetch-git
@@ -45,6 +53,6 @@
           ];
         };
       }) // {
-        overlays.default = overlay;
-      };
+      overlays.default = overlay;
+    };
 }


### PR DESCRIPTION
flake-utils's lib.eachDefaultSystem can be replaced by a few line of simple nix code.
this makes it so we don't have to depend on yet another dependency.

kept the systems input for the extensibility that flake-utils introduced transitively.